### PR TITLE
Send logurl in deployment status

### DIFF
--- a/out_command.go
+++ b/out_command.go
@@ -44,7 +44,10 @@ func (c *OutCommand) Run(sourceDir string, request OutRequest) (OutResponse, err
 	newStatus := &github.DeploymentStatusRequest{
 		State:       request.Params.State,
 		Description: request.Params.Description,
-		LogURL:      request.Params.LogURL,
+	}
+
+	if request.Params.LogURL != nil && *request.Params.LogURL != "" {
+		newStatus.LogURL = request.Params.LogURL
 	}
 
 	fmt.Fprintln(c.writer, "creating deployment status")

--- a/out_command.go
+++ b/out_command.go
@@ -44,6 +44,7 @@ func (c *OutCommand) Run(sourceDir string, request OutRequest) (OutResponse, err
 	newStatus := &github.DeploymentStatusRequest{
 		State:       request.Params.State,
 		Description: request.Params.Description,
+		LogURL:      request.Params.LogURL,
 	}
 
 	fmt.Fprintln(c.writer, "creating deployment status")

--- a/out_command_test.go
+++ b/out_command_test.go
@@ -67,8 +67,9 @@ var _ = Describe("Status Out Command", func() {
 			BeforeEach(func() {
 				request = resource.OutRequest{
 					Params: resource.OutParams{
-						ID:    github.String("1234"),
-						State: github.String("success"),
+						ID:     github.String("1234"),
+						State:  github.String("success"),
+						LogURL: github.String("http://foo.com"),
 					},
 				}
 			})
@@ -82,6 +83,7 @@ var _ = Describe("Status Out Command", func() {
 
 				Ω(id).Should(Equal(*github.Int64(1234)))
 				Ω(status.State).Should(Equal(github.String("success")))
+				Ω(status.LogURL).Should(Equal(github.String("http://foo.com")))
 			})
 
 			It("returns some metadata", func() {


### PR DESCRIPTION
The previous PRs added logURL to structs, but it doesn't actually send it to github