### PR TITLE
Make sure auto_merge is correctly parsed

### DIFF
--- a/deployment_out_command.go
+++ b/deployment_out_command.go
@@ -66,9 +66,6 @@ func (c *DeploymentOutCommand) Run(sourceDir string, request OutRequest) (OutRes
 	if request.Params.Description != nil {
 		newDeployment.Description = request.Params.Description
 	}
-	if request.Params.AutoMerge != nil {
-		newDeployment.AutoMerge = request.Params.AutoMerge
-	}
 
 	if request.Params.AutoMerge != nil {
 		newDeployment.AutoMerge = request.Params.AutoMerge

--- a/resources_test.go
+++ b/resources_test.go
@@ -62,7 +62,8 @@ var _ = Describe("Resources", func() {
 					"task": "task-string",
 					"environment": "environment-string",
 					"description": "description-string",
-					"log_url": "https://foo.com"
+					"log_url": "https://foo.com",
+					"auto_merge": false
 					}
 				}`))
 			err := json.NewDecoder(r).Decode(&p)
@@ -75,6 +76,7 @@ var _ = Describe("Resources", func() {
 			Ω(*p.Params.Environment).Should(Equal("environment-string"))
 			Ω(*p.Params.Description).Should(Equal("description-string"))
 			Ω(*p.Params.LogURL).Should(Equal("https://foo.com"))
+			Ω(*p.Params.AutoMerge).Should(Equal(false))
 		})
 
 		It("gets values from files", func() {


### PR DESCRIPTION
`auto_merge` is true by default for github, but we explicitly set it to false in our pipeline manager tooling. Unfortunately, the deployment resource never parsed it, hence this PR